### PR TITLE
Fix of showing items when the main button is transparent

### DIFF
--- a/ALRadial/ALRadial/ALRadialMenu.m
+++ b/ALRadial/ALRadial/ALRadialMenu.m
@@ -85,6 +85,10 @@
 		popupButton.bouncePoint = bounce;
 		popupButton.originPoint = origin;
         popupButton.shouldFade = self.fadeItems;
+        
+        if (popupButton.shouldFade) {
+            popupButton.alpha = 0.0;
+        }
 		
 		//set the button tag, delegate, and target action
 		popupButton.tag = currentItem;


### PR DESCRIPTION
Hi @alattis, this Pull Request is a fix for #24 (which enables fade-in and fade-out of the items during animation). It allows showing items when the main menu button is transparent. Could you merge it to the main repo?